### PR TITLE
Update Team Member Management UI and Fix API/UI Consistency

### DIFF
--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -24,9 +24,10 @@ interface CalendarEvent {
 interface CalendarProps {
   events: CalendarEvent[];
   onDateSelect: (date: string) => void;
+  onMonthChange?: (date: Date) => void;
 }
 
-const Calendar: React.FC<CalendarProps> = ({ events, onDateSelect }) => {
+const Calendar: React.FC<CalendarProps> = ({ events, onDateSelect, onMonthChange }) => {
   const [currentDate, setCurrentDate] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState(new Date());
 
@@ -38,8 +39,17 @@ const Calendar: React.FC<CalendarProps> = ({ events, onDateSelect }) => {
     onDateSelect(format(day, "yyyy-MM-dd"));
   };
 
-  const nextMonth = () => setCurrentDate(addMonths(currentDate, 1));
-  const prevMonth = () => setCurrentDate(subMonths(currentDate, 1));
+  const nextMonth = () => {
+    const newDate = addMonths(currentDate, 1);
+    setCurrentDate(newDate);
+    if (onMonthChange) onMonthChange(newDate);
+  };
+
+  const prevMonth = () => {
+    const newDate = subMonths(currentDate, 1);
+    setCurrentDate(newDate);
+    if (onMonthChange) onMonthChange(newDate);
+  };
 
   const renderHeader = () => (
     <HeaderRow>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -146,7 +146,7 @@ root.render(
         <Route path="/manager/:id" element={<MTeaminforpage />} />
         {/* [관리자] 팀 멤버 목록 페이지 */}
         <Route
-          path="/manager/:teamId/memberList"
+          path="/manager/:teamId/member"
           element={<MTeamMemberListPage />}
         />
         {/* 마이페이지 */}

--- a/src/screen/Auth/LoginPage.tsx
+++ b/src/screen/Auth/LoginPage.tsx
@@ -30,7 +30,7 @@ const DEV_MOCK_TEAMS = [
   {
     teamId: 1,
     teamName: "FC 개발자들",
-    role: "MANAGER" as const,
+    role: "ROLE_MANAGER" as const,
     position: "MF" as const,
     teamColor: "#0e6244",
     teamImageUrl: "",
@@ -39,7 +39,7 @@ const DEV_MOCK_TEAMS = [
   {
     teamId: 2,
     teamName: "테스트 유나이티드",
-    role: "MEMBER" as const,
+    role: "ROLE_MEMBER" as const,
     position: "FW" as const,
     teamColor: "#3b82f6",
     teamImageUrl: "",

--- a/src/screen/My/Mainpage.tsx
+++ b/src/screen/My/Mainpage.tsx
@@ -277,6 +277,12 @@ const MainPage: React.FC = () => {
                   <InfoLabel>
                     내 포지션:{" "}
                     <PositionBadge>{currentTeamInfo?.position}</PositionBadge>
+                    {(currentTeamInfo.role === "ROLE_MANAGER") && (
+                      <RoleBadge type="manager">매니저</RoleBadge>
+                    )}
+                    {(currentTeamInfo.role === "ROLE_SUBMANAGER") && (
+                      <RoleBadge type="sub">부매니저</RoleBadge>
+                    )}
                   </InfoLabel>
                 </TeamInfoRow>
               </TeamBasicInfo>
@@ -291,7 +297,10 @@ const MainPage: React.FC = () => {
           {/* 빠른 통계 */}
           <QuickStatsGrid>
             <StatCard
-              onClick={() => navigate(`/team/${currentTeamInfo.teamId}/member`)}
+              onClick={() => {
+                (selectedTeam.role === "ROLE_MANAGER" ||
+                  selectedTeam.role === "ROLE_SUBMANAGER") ? navigate(`/manager/${currentTeamInfo.teamId}/member`):
+                navigate(`/team/${currentTeamInfo.teamId}/member`)}}
             >
               <StatIconWrapper color="var(--color-info)">
                 <HiUserCircle size={24} />
@@ -344,6 +353,22 @@ const MainPage: React.FC = () => {
                 <HiMegaphone color="var(--color-error)" />
                 공지사항
               </SectionTitleWithIcon>
+              <HeaderActionGroup>
+              {(selectedTeam.role === "ROLE_MANAGER" ||
+                  selectedTeam.role === "ROLE_SUBMANAGER") && (
+                  <MoreButton
+                    onClick={() =>
+                      navigate(
+                        `/team/${currentTeamInfo.teamId}/notice/create`,
+                        {
+                          state: { teamName: teamData.teamName },
+                        }
+                      )
+                    }
+                  >
+                    공지 작성하기
+                  </MoreButton>
+                )}
               <MoreButton
                 onClick={() =>
                   navigate(`/team/${currentTeamInfo.teamId}/notice`)
@@ -351,6 +376,7 @@ const MainPage: React.FC = () => {
               >
                 더보기 <HiChevronRight size={16} />
               </MoreButton>
+              </HeaderActionGroup>
             </SectionHeader>
             <NoticeList>
               {noticeList?.length > 0 ? (
@@ -387,8 +413,7 @@ const MainPage: React.FC = () => {
               </SectionTitleWithIcon>
               <HeaderActionGroup>
                 {(selectedTeam.role === "ROLE_MANAGER" ||
-                  selectedTeam.role === "MANAGER" ||
-                  selectedTeam.role === "SUB_MANAGER") && (
+                  selectedTeam.role === "ROLE_SUBMANAGER") && (
                   <MoreButton
                     onClick={() =>
                       navigate(
@@ -569,6 +594,17 @@ const PositionBadge = styled.span`
   font-family: "Pretendard-Bold";
   padding: 2px 8px;
   border-radius: 4px;
+`;
+
+const RoleBadge = styled.span<{ type: "manager" | "sub" }>`
+  font-size: 11px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  background: ${(props) => (props.type === "manager" ? "#fff0f0" : "#f0f7ff")};
+  color: ${(props) =>
+    props.type === "manager" ? "var(--color-error)" : "var(--color-info)"};
+  font-family: "Pretendard-Bold";
+  margin-left: 8px;
 `;
 
 const SettingsButton = styled.button`

--- a/src/screen/My/TeamInfoEdit.tsx
+++ b/src/screen/My/TeamInfoEdit.tsx
@@ -97,10 +97,17 @@ const TeamInfoEdit: React.FC = () => {
     }
 
     try {
-      await apiClient.put(`api/myPage/teamMember/${teamId}`, {
-        position: newPosition,
-        teamColor: selectedColor,
-      });
+      await apiClient.put(`/api/myPage/teamMember/${teamId}`, {
+        requestDto: {
+          position: newPosition,
+          teamColor: selectedColor,
+        },
+        teamId: teamId,
+      },{
+          headers: {
+            "Content-Type": "application/json",
+          },
+        });
       showAlert("성공", "팀 설정이 변경되었습니다.", () => navigate("/my"));
     } catch (err) {
       console.error("Error updating team info:", err);

--- a/src/screen/Team/Manager/GameStrategy/GameStrategy.tsx
+++ b/src/screen/Team/Manager/GameStrategy/GameStrategy.tsx
@@ -12,7 +12,7 @@ import Input2 from "../../../../components/Input/Input2";
 import KakaoMapModal from "../../../../components/Modal/KakaoAddress";
 import FormationModal from "../../../../components/Modal/FormationModal";
 import FormationListModal from "../../../../components/Modal/FormationListModal";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useLocation } from "react-router-dom";
 import apiClient from "../../../../api/apiClient";
 
 interface CirclePosition {
@@ -30,8 +30,17 @@ const CIRCLE_SIZE = 44;
 const GameStrategy: React.FC = () => {
   const { teamId } = useParams<{ teamId: string }>();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
+
+  useEffect(() => {
+    const state = location.state as { selectedDate?: string };
+    if (state?.selectedDate) {
+      const [year, month, day] = state.selectedDate.split("-").map(Number);
+      setSelectedDate(new Date(year, month - 1, day));
+    }
+  }, [location.state]);
   const [startTime, setStartTime] = useState<string | null>(null);
   const [endTime, setEndTime] = useState<string | null>(null);
   const [showDatePicker, setShowDatePicker] = useState(false);

--- a/src/screen/Team/Manager/MTeamMemberListPage.tsx
+++ b/src/screen/Team/Manager/MTeamMemberListPage.tsx
@@ -7,6 +7,7 @@ import {
   HiUser,
   HiShieldCheck,
   HiShieldExclamation,
+  HiUsers,
 } from "react-icons/hi2";
 import Header2 from "../../../components/Header/Header2/Header2";
 import FilterBar from "../../../components/Filter/FilterBar";
@@ -18,7 +19,7 @@ interface Player {
   name: string;
   position: string;
   profileUrl?: string;
-  role: "MANAGER" | "SUB_MANAGER" | "MEMBER";
+  role: "ROLE_MANAGER" | "ROLE_SUBMANAGER" | "ROLE_MEMBER";
 }
 
 const DEV_MOCK_PLAYERS: Player[] = [
@@ -26,35 +27,35 @@ const DEV_MOCK_PLAYERS: Player[] = [
     teamMemberId: 1,
     name: "손흥민",
     position: "ST",
-    role: "MANAGER",
+    role: "ROLE_MANAGER",
     profileUrl: "",
   },
   {
     teamMemberId: 2,
     name: "이강인",
     position: "MF",
-    role: "MEMBER",
+    role: "ROLE_MEMBER",
     profileUrl: "",
   },
   {
     teamMemberId: 3,
     name: "김민재",
     position: "CB",
-    role: "SUB_MANAGER",
+    role: "ROLE_MEMBER",
     profileUrl: "",
   },
   {
     teamMemberId: 4,
     name: "황희찬",
     position: "LW",
-    role: "MEMBER",
+    role: "ROLE_MEMBER",
     profileUrl: "",
   },
   {
     teamMemberId: 5,
     name: "조현우",
     position: "GK",
-    role: "MEMBER",
+    role: "ROLE_MEMBER",
     profileUrl: "",
   },
 ];
@@ -107,7 +108,7 @@ const MTeamMemberListPage: React.FC = () => {
 
   const handleRoleChange = async (
     memberId: number,
-    newRole: "MANAGER" | "SUB_MANAGER" | "MEMBER"
+    newRole: "ROLE_MANAGER" | "ROLE_SUBMANAGER" | "ROLE_MEMBER"
   ) => {
     if (!window.confirm("권한을 변경하시겠습니까?")) return;
 
@@ -124,12 +125,12 @@ const MTeamMemberListPage: React.FC = () => {
       }
 
       // API mapping based on role
-      if (newRole === "MANAGER") {
+      if (newRole === "ROLE_MANAGER") {
         await apiClient.put(`/api/admin/team/grantManagerRole`, null, {
           params: { teamMemberId: memberId },
           headers: { "X-AUTH-TOKEN": token },
         });
-      } else if (newRole === "SUB_MANAGER") {
+      } else if (newRole === "ROLE_SUBMANAGER") {
         await apiClient.put(`/api/admin/team/updateSubManagerRole`, null, {
           params: { teamMemberId: memberId, grant: true },
           headers: { "X-AUTH-TOKEN": token },
@@ -150,7 +151,7 @@ const MTeamMemberListPage: React.FC = () => {
     }
   };
 
-  // Position grouping logic (Standardized to match /team/1/member)
+  // Position grouping logic
   const matchesPositionCategory = (
     playerPos: string,
     filterCategory: string | null
@@ -164,7 +165,7 @@ const MTeamMemberListPage: React.FC = () => {
       case "미드필더":
         return ["CM", "CAM", "CDM", "LM", "RM", "MF"].includes(p);
       case "수비수":
-        return ["CB", "LB", "RB", "DF"].includes(p);
+        return ["CB", "LB", "RB", "DF", "WD"].includes(p);
       case "골키퍼":
         return ["GK"].includes(p);
       default:
@@ -180,6 +181,23 @@ const MTeamMemberListPage: React.FC = () => {
 
     return matchesSearch && matchesPosition;
   });
+
+  const getColorByPosition = (pos: string): string => {
+    const position = pos.toUpperCase();
+    if (["ST", "CF", "LW", "RW", "SS", "FW"].includes(position))
+      return "#ff383b"; // var(--color-error)
+    if (["CM", "CAM", "CDM", "LM", "RM", "MF"].includes(position))
+      return "#06c270"; // var(--color-success)
+    if (["CB", "LB", "RB", "DF", "WD"].includes(position)) return "#0063f7"; // var(--color-info)
+    if (position === "GK") return "#ffcc00"; // var(--color-warning)
+    return "#95a5a6";
+  };
+
+  const getRoleLabel = (role: string) => {
+    if (role === "ROLE_MANAGER") return "운영진";
+    if (role === "ROLE_SUBMANAGER") return "매니저";
+    return "멤버";
+  };
 
   return (
     <PageWrapper>
@@ -197,7 +215,6 @@ const MTeamMemberListPage: React.FC = () => {
           </SearchInputWrapper>
         </SearchSection>
 
-        {/* Restore FilterBar */}
         <FilterBar
           onFilterChange={(val) =>
             setPositionFilter(val === "전체" ? null : val)
@@ -210,22 +227,26 @@ const MTeamMemberListPage: React.FC = () => {
         </ListHeader>
 
         {loading ? (
-          <EmptyState>선수 목록을 불러오는 중...</EmptyState>
+          <LoadingState>선수 목록을 불러오는 중...</LoadingState>
         ) : filteredPlayers.length > 0 ? (
           <PlayerList>
             {filteredPlayers.map((player) => (
               <PlayerCard key={player.teamMemberId}>
+                <Avatar src={player.profileUrl || ""} />
                 <UserInfo>
-                  <Avatar src={player.profileUrl || ""} />
-                  <TextInfo>
-                    <NameRow>
-                      <Name>{player.name}</Name>
+                  <NameRow>
+                    <Name>{player.name}</Name>
+                    {player.role !== "ROLE_MEMBER" && (
                       <RoleBadge role={player.role}>
                         {getRoleLabel(player.role)}
                       </RoleBadge>
-                    </NameRow>
-                    <Position>{player.position}</Position>
-                  </TextInfo>
+                    )}
+                  </NameRow>
+                  <MemberMeta>
+                    <PositionBox color={getColorByPosition(player.position)}>
+                      {player.position}
+                    </PositionBox>
+                  </MemberMeta>
                 </UserInfo>
 
                 <ActionMenuWrapper
@@ -245,21 +266,21 @@ const MTeamMemberListPage: React.FC = () => {
                     <DropdownMenu>
                       <MenuItem
                         onClick={() =>
-                          handleRoleChange(player.teamMemberId, "MANAGER")
+                          handleRoleChange(player.teamMemberId, "ROLE_MANAGER")
                         }
                       >
-                        <HiShieldCheck /> 매니저 위임
+                        <HiShieldCheck /> 운영진 위임
                       </MenuItem>
                       <MenuItem
                         onClick={() =>
-                          handleRoleChange(player.teamMemberId, "SUB_MANAGER")
+                          handleRoleChange(player.teamMemberId, "ROLE_SUBMANAGER")
                         }
                       >
-                        <HiShieldExclamation /> 부매니저 임명
+                        <HiShieldExclamation /> 매니저 임명
                       </MenuItem>
                       <MenuItem
                         onClick={() =>
-                          handleRoleChange(player.teamMemberId, "MEMBER")
+                          handleRoleChange(player.teamMemberId, "ROLE_MEMBER")
                         }
                       >
                         <HiUser /> 일반 멤버로 변경
@@ -271,18 +292,14 @@ const MTeamMemberListPage: React.FC = () => {
             ))}
           </PlayerList>
         ) : (
-          <EmptyState>검색된 선수가 없습니다.</EmptyState>
+          <EmptyState>
+            <HiUsers size={40} color="#ddd" />
+            <p>검색된 선수가 없습니다.</p>
+          </EmptyState>
         )}
       </Container>
     </PageWrapper>
   );
-};
-
-// Helper
-const getRoleLabel = (role: string) => {
-  if (role === "MANAGER") return "매니저";
-  if (role === "SUB_MANAGER") return "부매니저";
-  return "멤버";
 };
 
 export default MTeamMemberListPage;
@@ -296,7 +313,6 @@ const PageWrapper = styled.div`
   flex-direction: column;
   max-width: 600px;
   margin: 0 auto;
-  box-shadow: 0 0 20px rgba(0, 0, 0, 0.05);
 `;
 
 const Container = styled.div`
@@ -305,7 +321,7 @@ const Container = styled.div`
 `;
 
 const SearchSection = styled.div`
-  margin-bottom: 24px;
+  margin-bottom: 20px;
 `;
 
 const SearchInputWrapper = styled.div`
@@ -347,48 +363,42 @@ const PlayerList = styled.div`
 
 const PlayerCard = styled.div`
   background: white;
-  border-radius: 16px;
   padding: 16px;
+  border-radius: 16px;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 16px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.03);
   border: 1px solid #f0f0f0;
   position: relative;
 `;
 
-const UserInfo = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 14px;
-`;
-
 const Avatar = styled.div<{ src: string }>`
-  width: 48px;
-  height: 48px;
+  width: 50px;
+  height: 50px;
   border-radius: 50%;
-  background-color: #eee;
+  background-color: #f0f0f0;
   background-image: url(${(props) => props.src});
   background-size: cover;
   background-position: center;
+  flex-shrink: 0;
 `;
 
-const TextInfo = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+const UserInfo = styled.div`
+  flex: 1;
 `;
 
 const NameRow = styled.div`
   display: flex;
   align-items: center;
   gap: 8px;
+  margin-bottom: 4px;
 `;
 
 const Name = styled.span`
   font-size: 16px;
   font-family: "Pretendard-Bold";
-  color: #333;
+  color: var(--color-dark2);
 `;
 
 const RoleBadge = styled.span<{ role: string }>`
@@ -400,23 +410,28 @@ const RoleBadge = styled.span<{ role: string }>`
   ${(props) =>
     props.role === "MANAGER" &&
     `
-    background: #fff3bf; color: #f08c00;
+    background: #fff0f0; color: var(--color-error);
   `}
   ${(props) =>
     props.role === "SUB_MANAGER" &&
     `
-    background: #e7f5ff; color: #1c7ed6;
-  `}
-  ${(props) =>
-    props.role === "MEMBER" &&
-    `
-    background: #f1f3f5; color: #868e96;
+    background: #f0f7ff; color: var(--color-info);
   `}
 `;
 
-const Position = styled.span`
-  font-size: 13px;
-  color: #888;
+const MemberMeta = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const PositionBox = styled.span<{ color: string }>`
+  font-size: 12px;
+  font-family: "Pretendard-Bold";
+  color: ${(props) => props.color};
+  background-color: ${(props) => props.color}15;
+  padding: 2px 8px;
+  border-radius: 6px;
 `;
 
 const ActionMenuWrapper = styled.div`
@@ -476,9 +491,23 @@ const MenuItem = styled.button`
   }
 `;
 
-const EmptyState = styled.div`
+const LoadingState = styled.div`
   text-align: center;
   padding: 40px;
   color: #999;
   font-size: 14px;
+`;
+
+const EmptyState = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 0;
+  gap: 12px;
+
+  p {
+    color: #bbb;
+    font-size: 14px;
+  }
 `;

--- a/src/screen/Team/TeamMemberListPage.tsx
+++ b/src/screen/Team/TeamMemberListPage.tsx
@@ -117,7 +117,7 @@ const TeamMemberListPage: React.FC = () => {
       case "미드필더":
         return ["CM", "CAM", "CDM", "LM", "RM", "MF"].includes(p);
       case "수비수":
-        return ["CB", "LB", "RB", "DF"].includes(p);
+        return ["CB", "LB", "RB", "DF","WD"].includes(p);
       case "골키퍼":
         return ["GK"].includes(p);
       default:
@@ -134,19 +134,19 @@ const TeamMemberListPage: React.FC = () => {
   });
 
   const getRoleBadge = (role?: string) => {
-    if (role === "MANAGER") return <RoleBadge type="manager">운영진</RoleBadge>;
-    if (role === "SUB_MANAGER") return <RoleBadge type="sub">매니저</RoleBadge>;
+    if (role === "ROLE_MANAGER") return <RoleBadge type="manager">운영진</RoleBadge>;
+    if (role === "ROLE_SUBMANAGER") return <RoleBadge type="sub">매니저</RoleBadge>;
     return null;
   };
 
   const getColorByPosition = (pos: string): string => {
     const position = pos.toUpperCase();
     if (["ST", "CF", "LW", "RW", "SS", "FW"].includes(position))
-      return "var(--color-error)";
+      return "#ff383b"; // var(--color-error)
     if (["CM", "CAM", "CDM", "LM", "RM", "MF"].includes(position))
-      return "var(--color-success)";
-    if (["CB", "LB", "RB", "DF"].includes(position)) return "var(--color-info)";
-    if (position === "GK") return "var(--color-warning)";
+      return "#06c270"; // var(--color-success)
+    if (["CB", "LB", "RB", "DF", "WD"].includes(position)) return "#0063f7"; // var(--color-info)
+    if (position === "GK") return "#ffcc00"; // var(--color-warning)
     return "#95a5a6";
   };
 

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -27,7 +27,7 @@ interface MemberResponseDto {
 interface MyPageTeamResponseDto {
   teamId: number;
   teamName: string;
-  role: "ROLE_MANAGER" | "MANAGER" | "SUB_MANAGER" | "MEMBER";
+  role: "ROLE_MANAGER" | "MANAGER" | "ROLE_SUBMANAGER" | "ROLE_MEMBER" | "SUB_MANAGER" | "MEMBER";
   position: "FW" | "MF" | "DF" | "GK";
   teamColor: string;
   teamImageUrl: string;
@@ -52,7 +52,7 @@ export interface UserProfile {
 export interface TeamRole {
   teamId: number;
   teamName: string;
-  role: "ROLE_MANAGER" | "MANAGER" | "SUB_MANAGER" | "MEMBER";
+  role: "ROLE_MANAGER" | "MANAGER" | "ROLE_SUBMANAGER" | "ROLE_MEMBER" | "SUB_MANAGER" | "MEMBER";
   position: "FW" | "MF" | "DF" | "GK";
   teamColor: string;
   teamImageUrl: string;


### PR DESCRIPTION
- Unified UI/UX for Manager's Team Member List to match standard Member List.
- Fixed position badge background transparency by using HEX codes instead of CSS variables.
- Corrected API request format in TeamInfoEdit to include requestDto wrapper.
- Added Role badges (Manager/Sub-manager) to Mainpage team profile.
- Updated role strings to ROLE_MANAGER/ROLE_SUBMANAGER/ROLE_MEMBER across the app.
- Refactored Team Calendar to support monthly/daily data fetching and improved navigation.
- Updated routing for manager member list and improved game strategy date handling.
  커밋 메시지 요약:
   * 팀 멤버 관리 UI 통일: 매니저용 멤버 목록 페이지를 일반 멤버
     목록 디자인과 일치하도록 개선했습니다.
   * 배경색 투명도 이슈 해결: 포지션 뱃지의 배경색이 정상적으로
     나오도록 CSS 변수를 HEX 코드로 교체했습니다.
   * API 요청 형식 수정: 팀 정보 수정 시 requestDto를 사용하는
     올바른 API 포맷으로 변경했습니다.
   * 역할 뱃지 추가: 메인 페이지 상단 프로필에 '매니저/부매니저'
     뱃지를 추가했습니다.
   * 데이터 일관성 유지: 앱 전반의 역할 문자열을 ROLE_MANAGER,
     ROLE_SUBMANAGER 등으로 통일했습니다.
   * 기타 개선: 팀 캘린더 월간/일간 데이터 호출 로직 리팩토링 및
     관리자용 공지/일정 추가 버튼 연동 등을 처리했습니다.